### PR TITLE
Add .gitattributes

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,6 @@
+/.gitattributes export-ignore
+/.gitignore export-ignore
+/.travis.yml export-ignore
+/index.html export-ignore
+/phpcs.xml export-ignore
+/tests export-ignore


### PR DESCRIPTION
The resources not intended for production should not be included in the Composer package since they unnecessarily increase the distribution package size and often become the source of security issues.